### PR TITLE
MVP - Add User Credential Checking and Fix Some API Bugs

### DIFF
--- a/Enums.ts
+++ b/Enums.ts
@@ -1,5 +1,6 @@
 export enum State {
     PARKED = "PARKED",
     TIMEOUT = "TIMEOUT",
-    UNDECIDED = "UNDECIDED"
+    UNDECIDED = "UNDECIDED",
+    LEFT_AREA = "LEFT_AREA"
 }

--- a/models/Credential.ts
+++ b/models/Credential.ts
@@ -1,0 +1,42 @@
+import { dbConnection } from './dbInit';
+import { Model, DataTypes, Optional } from 'sequelize';
+import bcrypt from 'bcrypt';
+
+export interface CredentialAttributes {
+  id?: number;
+  user_id: number;
+  email: string;
+  password: string;
+}
+
+export interface CredentialCreationAttributes extends Optional<CredentialAttributes, 'id'> {}
+
+export const Credential = dbConnection.define<Model<CredentialAttributes, CredentialCreationAttributes>>('Credential', {
+  id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+  user_id: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+  },
+  email: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  password: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+}, {
+  tableName: 'credentials',
+  timestamps: false,
+  underscored: true,
+  hooks: {
+    beforeCreate: async (credential: any) => {
+      const saltRounds = 10;
+      credential.password = await bcrypt.hash(credential.password, saltRounds);
+    },
+  },
+});

--- a/models/JoiSchemas.ts
+++ b/models/JoiSchemas.ts
@@ -1,44 +1,49 @@
 import Joi from "joi";
 
 export const userSchema = Joi.object({
-  vehicle_make: Joi.string()
+    email: Joi.string()
+    .required(),
+    password: Joi.string()
+    .required(),
+    vehicle_make: Joi.string()
     .alphanum()
     .required(),
-  vehicle_model: Joi.string()
+    vehicle_model: Joi.string()
     .alphanum()
     .required(),
-  vehicle_year: Joi.number()
+    vehicle_year: Joi.number()
     .required(),
-  vehicle_color: Joi.string()
+    vehicle_color: Joi.string()
     .required(),
-  license_plate: Joi.string()
+    license_plate: Joi.string()
     .required(),
-  tag_id: Joi.number(),
-  first_name: Joi.string()
+    tag_id: Joi.number(),
+    first_name: Joi.string()
     .required(),
-  last_name: Joi.string()
+    last_name: Joi.string()
     .required()
 });
 
 export const scheduleSchema = Joi.object({
-  user_id: Joi.number()
+    user_id: Joi.number()
     .required(),
-  time_in: Joi.string()
+    time_in: Joi.string()
     .required(),
-  time_out: Joi.string()
+    day_of_week: Joi.number()
     .required(),
-  day_of_week: Joi.number()
-    .required()
+    event_name: Joi.string()
+    .required(),
+    lots: Joi.object()
 });
 
 export const spotSchema = Joi.object({
-  is_handicap: Joi.bool()
+    is_handicap: Joi.bool()
     .required(),
-  latlong: [
-    Joi.number(),
-    Joi.number() 
-  ],
-  is_available: Joi.bool(),
-  row_id: Joi.number(),
-  lot_id: Joi.number()
+    latlong: [
+        Joi.number(),
+        Joi.number() 
+    ],
+    is_available: Joi.bool(),
+    row_id: Joi.number(),
+    lot_id: Joi.number()
 });

--- a/models/Lot_Activity.ts
+++ b/models/Lot_Activity.ts
@@ -32,7 +32,7 @@ export const Lot_Activity = dbConnection.define(
       allowNull: false,
     },
     status: {
-      type: DataTypes.ENUM("PARKED", "CANDIDATE", "VOID"),
+      type: DataTypes.ENUM("PARKED", "CANDIDATE", "VOID", "COMPLETE"),
       allowNull: false,
       defaultValue: "VOID",
     },

--- a/models/Parkinator.ts
+++ b/models/Parkinator.ts
@@ -67,7 +67,7 @@ const determineState = async (
   userId: number,
   longitude: number,
   latitude: number
-): Promise<State> => {
+): Promise<{state: State, spot_id: number | null}> => {
   try {
     const tagActivity = await Tag_Activity.findOne({
       where: { tag_id: tagId },
@@ -80,7 +80,7 @@ const determineState = async (
       if (unchangedLocationCounter >= 3) {
         const spotId = await getNearestSpotId(longitude, latitude);
         await updateSpotAndCreateLotActivity(spotId, userId, tagActivityId);
-        return State.PARKED;
+        return { state: State.PARKED, spot_id: spotId };
       } else {
           const tagLocation = tagActivity?.getDataValue("location");
 
@@ -95,13 +95,13 @@ const determineState = async (
                   await tagActivity?.save();
               }
           }
-          return State.UNDECIDED;
+          return { state: State.UNDECIDED, spot_id: null };
       }
     } else if (message === "DISCONNECT") {
         const spotId = await getNearestSpotId(longitude, latitude);
         const activityId = tagActivity?.getDataValue("tag_activity_id") || tagActivityId;
         await updateSpotAndCreateLotActivity(spotId, userId, activityId);
-        return State.PARKED;
+        return {state: State.PARKED, spot_id: spotId };
     } else {
         throw new Error("Invalid message provided. Possible values: CHECK | DISCONNECT");
     }

--- a/models/Schedule.ts
+++ b/models/Schedule.ts
@@ -15,14 +15,18 @@ export const Schedule = dbConnection.define('Schedule', {
     time_in: {
         type: DataTypes.TIME,
         allowNull: false
-    },
-    time_out: {
-        type: DataTypes.TIME,
-        allowNull: false
-    },
+    }, 
     day_of_week: {
         type: DataTypes.TINYINT,
         allowNull: false
+    },
+    event_name: {
+        type: DataTypes.STRING,
+        allowNull: false,
+    },
+    lots: {
+        type: DataTypes.JSON, // Stores the lots the user wants to associate the this schedule event.
+        allowNull: true
     }
 }, {
     tableName: "schedules",

--- a/models/Tag.ts
+++ b/models/Tag.ts
@@ -1,7 +1,15 @@
 import { dbConnection } from './dbInit';
-import { DataTypes } from 'sequelize';
+import { DataTypes, Optional, Model } from 'sequelize';
 
-export const Tag = dbConnection.define(
+export interface TagAttributes {
+  tag_id: number;
+  user_id: number;
+  serial_code: string;
+}
+
+export interface TagCreationAttributes extends Optional<TagAttributes, 'tag_id'> {}
+
+export const Tag = dbConnection.define<Model<TagAttributes, TagCreationAttributes>>(
 	'Tag',
 	{
 		tag_id: {

--- a/models/User.ts
+++ b/models/User.ts
@@ -1,7 +1,22 @@
 import { dbConnection } from "./dbInit";
-import { DataTypes } from "sequelize";
+import { DataTypes, Model, Optional } from "sequelize";
 
-export const User = dbConnection.define('User', {
+export interface UserAttributes {
+  user_id: number;
+  vehicle_make: string;
+  vehicle_model: string;
+  vehicle_year: number;
+  vehicle_color: string;
+  license_plate: string;
+  tag_id?: number;
+  first_name: string;
+  last_name: string;
+}
+
+export interface UserCreationAttributes extends Optional<UserAttributes, 'user_id'> {}
+
+
+export const User = dbConnection.define<Model<UserAttributes, UserCreationAttributes>>('User', {
     user_id: {
         type: DataTypes.INTEGER,
         autoIncrement: true,
@@ -43,3 +58,4 @@ export const User = dbConnection.define('User', {
     timestamps: false,
     underscored: true
 });
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "bcrypt": "^5.1.1",
         "body-parser": "^1.20.2",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
@@ -17,6 +18,7 @@
         "sequelize": "^6.35.1"
       },
       "devDependencies": {
+        "@types/bcrypt": "^5.0.2",
         "@types/express": "^4.17.21",
         "@types/node": "^20.10.0",
         "concurrently": "^8.2.2",
@@ -46,6 +48,39 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -63,6 +98,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
+      "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
@@ -181,8 +225,7 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -193,11 +236,42 @@
         "negotiator": "0.6.3"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -218,6 +292,23 @@
         "picomatch": "^2.0.4"
       }
     },
+    "node_modules/aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -226,8 +317,20 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/bcrypt": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
+      "integrity": "sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.11",
+        "node-addon-api": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -258,7 +361,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -325,6 +427,14 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -351,11 +461,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/concurrently": {
       "version": "8.2.2",
@@ -373,6 +490,11 @@
         "tree-kill": "^1.2.2",
         "yargs": "^17.7.2"
       }
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -424,6 +546,11 @@
         "has-property-descriptors": "^1.0.0"
       }
     },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
     "node_modules/denque": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
@@ -438,6 +565,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.3.1",
@@ -457,8 +592,7 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -582,6 +716,33 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -593,6 +754,25 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/generate-function": {
       "version": "2.3.1",
@@ -617,6 +797,25 @@
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
         "hasown": "^2.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -660,6 +859,11 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    },
     "node_modules/hasown": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
@@ -680,6 +884,39 @@
         "toidentifier": "1.0.1"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -698,6 +935,15 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.4.tgz",
       "integrity": "sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw=="
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -727,8 +973,7 @@
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
@@ -780,6 +1025,28 @@
         "yallist": "^4.0.0"
       }
     },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -817,9 +1084,50 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/moment": {
@@ -886,6 +1194,30 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
+    "node_modules/node-addon-api": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/nodemon": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.1.tgz",
@@ -949,6 +1281,25 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
@@ -962,10 +1313,26 @@
         "ee-first": "1.1.1"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
@@ -1022,6 +1389,19 @@
         "unpipe": "1.0.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -1047,6 +1427,20 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
       "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/rxjs": {
       "version": "7.8.1",
@@ -1157,6 +1551,11 @@
         "send": "0.18.0"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
     "node_modules/set-function-length": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
@@ -1190,6 +1589,11 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -1215,11 +1619,18 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -1230,7 +1641,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       }
@@ -1242,6 +1652,22 @@
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/to-regex-range": {
@@ -1271,6 +1697,11 @@
       "dependencies": {
         "nopt": "~1.0.10"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -1315,6 +1746,11 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -1335,6 +1771,28 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
     "node_modules/wkx": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
@@ -1353,6 +1811,11 @@
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "bcrypt": "^5.1.1",
     "body-parser": "^1.20.2",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
@@ -31,6 +32,7 @@
     "sequelize": "^6.35.1"
   },
   "devDependencies": {
+    "@types/bcrypt": "^5.0.2",
     "@types/express": "^4.17.21",
     "@types/node": "^20.10.0",
     "concurrently": "^8.2.2",

--- a/routes/lots.ts
+++ b/routes/lots.ts
@@ -38,7 +38,7 @@ lotsRouter.get('/getLots/:lot_id', async (req, res) => {
 
 lotsRouter.get('/getOccupancy', async (_req, res) => {
     try {
-        const allSpotCounts = await Parking_Spot.findAndCountAll({
+        const totalCount = await Parking_Spot.findAndCountAll({
             attributes: [
                 'lot_id'
             ],
@@ -55,7 +55,7 @@ lotsRouter.get('/getOccupancy', async (_req, res) => {
             }
         });
 
-        res.status(200).send({ allSpotCounts, occupiedSpotCounts });
+        res.status(200).send({ totalCount, occupiedSpotCounts });
         } catch (error) {
             console.log(error);
             res.status(200).send("Unable to get occupancy.");

--- a/routes/schedules.ts
+++ b/routes/schedules.ts
@@ -4,81 +4,88 @@ import bodyParser from "body-parser";
 import { scheduleSchema } from "../models/JoiSchemas";
 
 export const schedulesRouter: Router = express.Router();
-
 const jsonParser = bodyParser.json();
 
 schedulesRouter.get('/', (_req, res) => {
-    res.send('Schedules endpoint hit.');
+  res.send('Schedules endpoint hit.');
 });
 
 schedulesRouter.get('/getUserSchedule/:id', async (req, res) => {
-    try {
-        const resSchedule = await Schedule.findAll({
-            where: {
-                'user_id': parseInt(req.params.id)
-            }
-        })
-        res.send(resSchedule);
-    } catch(err) {
-        console.log(err);
-        res.status(200).send(err);
-    }
+  try {
+    const resSchedule = await Schedule.findAll({
+      where: {
+        'user_id': parseInt(req.params.id)
+      }
+    });
+    res.send(resSchedule);
+  } catch (err) {
+    console.log(err);
+    res.status(200).send(err);
+  }
 });
 
 // Expects request body to be JSON data
 schedulesRouter.post('/setSchedule', jsonParser, async (req, res) => {
-    const scheduleData = {
-        user_id: req.body.userId || -1,
-        time_in: req.body.timeIn || null,
-        time_out: req.body.timeOut || null,
-        day_of_week: req.body.dayOfWeek || -1
-    };
+  const scheduleData = {
+    user_id: req.body.userId || -1,
+    time_in: req.body.timeIn || null,
+    day_of_week: req.body.dayOfWeek || -1,
+    event_name: req.body.eventName || "",
+    lots: req.body.lots || null
+  };
 
-    try {
-        await scheduleSchema.validateAsync(scheduleData);
-        const newScheduleEntry = await Schedule.create(scheduleData);
-        res.status(200).send(newScheduleEntry);
-    } catch(err) {
-        console.log(err);
-        res.status(200).send(err);
-    }
+  try {
+    await scheduleSchema.validateAsync(scheduleData);
+    const newScheduleEntry = await Schedule.create(scheduleData);
+    res.status(200).send(newScheduleEntry);
+  } catch (err) {
+    console.log(err);
+    res.status(200).send(err);
+  }
 });
 
 // Expects request body to be JSON data
 schedulesRouter.patch('/updateSchedule/:id', jsonParser, async (req, res) => {
-    const updatedData = {
-        ...req.body
-    };
+  const updatedData = {
+    ...req.body
+  };
 
-    try {
-        const entryToBeChanged = await Schedule.findOne({
-            where: {
-                'schedule_id': req.params.id
-            }
-        });
+  try {
+    const entryToBeChanged = await Schedule.findOne({
+      where: {
+        'schedule_id': req.params.id
+      }
+    });
 
-        entryToBeChanged?.set(updatedData);
-
-        const response = await entryToBeChanged?.save();
-        res.status(200).send(response);
-    } catch (err) {
-        console.log(err);
-        res.status(200).send(err);
+    if (entryToBeChanged) {
+      entryToBeChanged.set(updatedData);
+      const response = await entryToBeChanged.save();
+      res.status(200).send(response);
+    } else {
+      res.status(200).send("Schedule entry not found");
     }
+  } catch (err) {
+    console.log(err);
+    res.status(200).send(err);
+  }
 });
 
 schedulesRouter.delete('/deleteScheduleEntry/:id', async (req, res) => {
-    try {
-        const entryToBeDeleted = await Schedule.findOne({
-            where: {
-                'schedule_id': req.params.id
-            }
-        });
+  try {
+    const entryToBeDeleted = await Schedule.findOne({
+      where: {
+        'schedule_id': req.params.id
+      }
+    });
 
-        const response = await entryToBeDeleted?.destroy();
-        res.status(200).send(response);
-    } catch (err) {
-        console.log(err);
-        res.status(200).send(err);
+    if (entryToBeDeleted) {
+      const response = await entryToBeDeleted.destroy();
+      res.status(200).send(response);
+    } else {
+      res.status(200).send("Schedule entry not found");
     }
+  } catch (err) {
+    console.log(err);
+    res.status(200).send(err);
+  }
 });

--- a/routes/tagActivity.ts
+++ b/routes/tagActivity.ts
@@ -1,6 +1,9 @@
 import express, { Router } from "express";
 import { Tag_Activity } from "../models/Tag_Activity";
+import { Lot_Activity } from '../models/Lot_Activity';
+import { Parking_Spot } from '../models/Parking_Spot';
 import Parkinator from "../models/Parkinator";
+import { State } from "../Enums";
 import { QueryTypes } from "sequelize";
 import bodyParser from "body-parser";
 
@@ -18,7 +21,7 @@ tagActivityRouter.get("/:id/location", async (req, res) => {
     });
     if (!tag_activity) throw new Error("Tag not found.");
     const lastLocation = await Tag_Activity.sequelize?.query(
-      `SELECT ST_AsText(last_longlat) FROM tags WHERE tag_id = ${id}`,
+      `SELECT ST_AsText(location) FROM tag_activity WHERE tag_id = ${id}`,
       { type: QueryTypes.SELECT },
     );
     res.status(200).json(lastLocation);
@@ -43,19 +46,13 @@ tagActivityRouter.put("/:id/location", jsonParser, async (req, res) => {
     }
 
     try {
-        let tag_activity = await Tag_Activity.findOne({
-            where: {
-                tag_id: parseInt(id),
-            },
-        });
-
+        let tag_activity = await Tag_Activity.findOne({ where: { tag_id: parseInt(id) } });
         if (!tag_activity) {
             const tagActivityData = {
                 tag_id: id,
                 location: { type: "Point", coordinates: [long, lat] },
                 update_timestamp: `${currentTime.getHours()}:${currentTime.getMinutes()}:${currentTime.getSeconds()}`,
             };
-
             tag_activity = await Tag_Activity.create(tagActivityData);
         } else {
             await tag_activity.update({
@@ -64,7 +61,7 @@ tagActivityRouter.put("/:id/location", jsonParser, async (req, res) => {
             });
         }
 
-        const state = await Parkinator.determineState(
+        const result = await Parkinator.determineState(
             message,
             parseInt(id),
             tag_activity.getDataValue("tag_activity_id"),
@@ -73,9 +70,54 @@ tagActivityRouter.put("/:id/location", jsonParser, async (req, res) => {
             parseFloat(lat)
         );
 
-        return res.status(200).json({ success: true, state });
+        if (result.state === State.UNDECIDED) {
+            await tag_activity.update({ status: "IN PROGRESS" });
+        } else if (result.state === State.PARKED) {
+            await tag_activity.update({ status: "PARKED" });
+        }
+
+        return res.status(200).json({ success: true, state: result.state, spotId: result.spot_id });
     } catch (error) {
         console.error("Error updating tag location:", error);
         return res.status(200).json({ success: false, message: error });
     }
 });
+
+tagActivityRouter.post("/unparked/:spot_id", jsonParser, async (req, res) => {
+  const { spot_id } = req.params;
+  const currentTime = new Date();
+  const pTimeOut = `${currentTime.getHours()}:${currentTime.getMinutes()}:${currentTime.getSeconds()}`;
+
+  try {
+    // Update the lot activity table
+    await Lot_Activity.update(
+      { ptime_out: pTimeOut, status: "VOID" },
+      { where: { spot_id: parseInt(spot_id), status: "PARKED" } }
+    );
+
+    // Update the parking spot availability
+    await Parking_Spot.update(
+      { is_available: 1 },
+      { where: { spot_id: parseInt(spot_id) } }
+    );
+
+    // Update the corresponding tag's tag_activity status
+    const lotActivity = await Lot_Activity.findOne({
+      where: { spot_id: parseInt(spot_id), status: "VOID" },
+      order: [["activity_id", "DESC"]],
+    });
+    if (lotActivity) {
+      const tagActivityId = lotActivity.getDataValue("tag_activity_id");
+      await Tag_Activity.update(
+        { status: "VOID" },
+        { where: { tag_activity_id: tagActivityId } }
+      );
+    }
+
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    console.error("Error updating unparked status:", error);
+    return res.status(200).json({ success: false, message: error });
+  }
+});
+


### PR DESCRIPTION
**Notes/Changes:**
* You should now be able to send "email" and "password" keys in the createUser endpoint as part of the body.
* There is now an endpoint called "/users/validateLogin" where you can send the email and password as part of the body and it will return the user if there is a match.
* There is now an explicit endpoint called "/tagActivity/unparked/:spot_id" where you send the spot_id the user is leaving from and it does all the backend cleanup needed in the database.
* It was an error with the query that broke after recent changes, I fixed it now!
* I changed the schema of the schedules table around to match the format Drew wants, as well as the backend stuff that was relying on the old structure.
* I changed the names of the payload to be consistent with the individual lot occupancy info as Drew wanted.